### PR TITLE
perf: optimize import trace locations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,17 +141,41 @@ interface PendingViolation {
   warnedMessages: Set<string> | undefined
 }
 
-/** Convert a byte offset in source code to a 1-indexed line and 0-indexed column. */
-function offsetToLineColumn(code: string, offset: number): { line: number, column: number } {
+/** Map imports to 1-indexed lines and 0-indexed UTF-16 columns. */
+function getImportLocations(code: string, imports: readonly { n: string | undefined, s: number, ss: number, se: number }[]): Map<string, ImportLocation> {
+  const locations = new Map<string, ImportLocation>()
   let line = 1
   let lastNewline = -1
-  for (let i = 0; i < offset && i < code.length; i++) {
-    if (code[i] === '\n') {
-      line++
-      lastNewline = i
+  let offset = 0
+
+  for (const imp of imports) {
+    if (!imp.n)
+      continue
+
+    // es-module-lexer emits source-ordered imports. Reset defensively if that ever changes.
+    if (imp.s < offset) {
+      line = 1
+      lastNewline = -1
+      offset = 0
     }
+
+    while (offset < imp.s && offset < code.length) {
+      if (code[offset] === '\n') {
+        line++
+        lastNewline = offset
+      }
+      offset++
+    }
+
+    locations.set(imp.n, {
+      line,
+      column: imp.s - lastNewline - 1,
+      statementStart: imp.ss,
+      statementEnd: imp.se,
+    })
   }
-  return { line, column: offset - lastNewline - 1 }
+
+  return locations
 }
 
 /** Generate a code snippet with context lines, a `>` marker, and a `^` caret. */
@@ -524,17 +548,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
 
       try {
         const [imports] = parse(code, id)
-        for (const imp of imports) {
-          if (imp.n) {
-            const { line, column } = offsetToLineColumn(code, imp.s)
-            importMap.set(imp.n, {
-              line,
-              column,
-              statementStart: imp.ss,
-              statementEnd: imp.se,
-            })
-          }
-        }
+        importMap = getImportLocations(code, imports)
 
         // extract the combined source map for original-source snippets.
         if (getCombinedSourcemap) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -154,6 +154,50 @@ describe('impound plugin', () => {
 })
 
 describe('trace mode', () => {
+  it.each([
+    {
+      name: 'the last duplicate import',
+      code: [
+        'import \'secret\'',
+        'const value = 1',
+        'import \'secret\'',
+      ].join('\n'),
+      line: 3,
+      column: 8,
+    },
+    {
+      name: 'a multiline import',
+      code: [
+        'import {',
+        '  value,',
+        '} from \'secret\'',
+      ].join('\n'),
+      line: 3,
+      column: 8,
+    },
+    {
+      name: 'an import after a nonliteral dynamic import',
+      code: [
+        'import(name + suffix)',
+        '',
+        'import \'secret\'',
+      ].join('\n'),
+      line: 3,
+      column: 8,
+    },
+    {
+      name: 'an import after astral Unicode',
+      code: 'const value = \'😀\'; import \'secret\'',
+      line: 1,
+      column: 28,
+    },
+  ])('preserves the diagnostic location for $name', async ({ code, line, column }) => {
+    const violation = await getTraceViolation(code)
+
+    expect(violation.snippet).toMatchObject({ line, column })
+    expect(violation.snippet!.text).toContain(`${' '.repeat(column)}^`)
+  })
+
   it('includes import trace in violation', async () => {
     const result = await processTrace({
       trace: true,
@@ -1063,6 +1107,27 @@ async function processTrace(opts: ImpoundOptions) {
   }
   const libs = ['secret']
   return buildWithTrace(files, libs, opts)
+}
+
+async function getTraceViolation(code: string): Promise<ImpoundViolationInfo> {
+  let violation: ImpoundViolationInfo | undefined
+  const plugins = ImpoundPlugin.rollup({
+    trace: true,
+    patterns: [['secret', 'Invalid import']],
+    onViolation: (info) => {
+      violation = info
+      return false
+    },
+  })
+  const pluginArray = Array.isArray(plugins) ? plugins : [plugins]
+  const impoundPlugin = pluginArray.find(plugin => plugin.name === 'impound')!
+  const tracePlugin = pluginArray.find(plugin => plugin.name === 'impound:trace')!
+
+  await (tracePlugin as any).transform.call({}, code, 'entry.js')
+  await (impoundPlugin as any).resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+
+  expect(violation).toBeDefined()
+  return violation!
 }
 
 async function process(code: string, opts: ImpoundOptions, importer = 'entry.js') {


### PR DESCRIPTION
This PR improves `impound`'s runtime performance by optimizing import location calculation from repeated source scans to a single forward pass.

The complexity improves from ~ O(imports × source length) to O(source length).

Preliminary bench on my machine (Node.js v24.17.0 on macOS arm64) shows that the location mapping itself improved by 28.5~1823x

| Imports | Source size | Old | New | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 6.6 KB | 0.721 ms | 0.025 ms | 28.5x |
| 1,000 | 67.8 KB | 76.247 ms | 0.189 ms | 402.9x |
| 5,000 | 347.8 KB | 1,979.085 ms | 1.086 ms | 1,823.1x |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized import location tracking calculations in trace mode for better performance and maintainability.

* **Tests**
  * Expanded test coverage for trace mode to verify accurate line and column information in violation reports across various import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->