### PR TITLE
fix: add filters to prevent over-processing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createUnplugin } from 'unplugin'
 import { createFilter } from 'unplugin-utils'
 
 const PROXY_ID = '\0impound:proxy'
+const PROXY_ID_RE = /^\0impound:proxy$/
 
 // based on https://github.com/unjs/mocked-exports
 const PROXY_CODE = `
@@ -114,6 +115,8 @@ export interface ImpoundSharedOptions {
 export type ImpoundOptions = (ImpoundSharedOptions & ImpoundMatcherOptions) | (ImpoundSharedOptions & { matchers: ImpoundMatcherOptions[] })
 
 const RELATIVE_IMPORT_RE = /^\.\.?\//
+
+const BINARY_ASSET_RE = /\.(?:png|jpe?g|gif|webp|avif|bmp|ico|woff2?|[ot]tf|eot|mp[34]|webm|ogg|wav|flac|pdf|zip|gz|wasm)(?:\?.*)?$/i
 
 interface ImportLocation {
   line: number
@@ -427,10 +430,13 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
     return {
       name: 'impound',
       enforce: 'pre' as const,
-      load(id: string) {
-        if (id === PROXY_ID) {
-          return PROXY_CODE
-        }
+      load: {
+        filter: { id: PROXY_ID_RE },
+        handler(id: string) {
+          if (id === PROXY_ID) {
+            return PROXY_CODE
+          }
+        },
       },
       resolveId(this: UnpluginBuildContext & UnpluginContext, id: string, importer: string | undefined, resolveOptions?: { isEntry?: boolean }) {
         if (id === PROXY_ID) {
@@ -541,6 +547,9 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
   if (traceEnabled) {
     // shared transform logic for module graph building and flushing pending violations.
     async function traceTransform(code: string, id: string, getCombinedSourcemap?: () => unknown): Promise<void> {
+      if (BINARY_ASSET_RE.test(id))
+        return
+
       await init
       let importMap = new Map<string, ImportLocation>()
       let originalCode: string | undefined
@@ -614,6 +623,13 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
       },
     }
 
+    const filteredTransformWithSourceMap = {
+      transform: {
+        filter: { id: { exclude: BINARY_ASSET_RE } },
+        handler: transformWithSourceMap.transform,
+      },
+    }
+
     const tracePlugin: UnpluginOptions = {
       name: 'impound:trace',
       resolveId(_id, importer, resolveOptions) {
@@ -623,10 +639,13 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
         }
         return null
       },
-      transform: traceTransform,
+      transform: {
+        filter: { id: { exclude: BINARY_ASSET_RE } },
+        handler: traceTransform,
+      },
       rollup: transformWithSourceMap,
-      vite: transformWithSourceMap,
-      rolldown: transformWithSourceMap,
+      vite: filteredTransformWithSourceMap,
+      rolldown: filteredTransformWithSourceMap,
     }
     plugins.push(tracePlugin)
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import type { RollupError } from 'rollup'
+import type { ObjectHook } from 'unplugin'
 import type { ImpoundOptions, ImpoundViolationInfo } from '../src'
 import { rollup } from 'rollup'
 import { describe, expect, it, vi } from 'vitest'
@@ -1157,3 +1158,50 @@ async function process(code: string, opts: ImpoundOptions, importer = 'entry.js'
     return e as RollupError
   }
 }
+
+describe('hook filters', () => {
+  it('should only claim the proxy module in load', () => {
+    const rawPlugins = ImpoundPlugin.raw({ patterns: [['bar']] }, { framework: 'rollup', versions: {} })
+    const plugins = Array.isArray(rawPlugins) ? rawPlugins : [rawPlugins]
+    const impoundPlugin = plugins.find(p => p.name === 'impound')!
+
+    const loadFilter = (impoundPlugin.load as ObjectHook<any, 'id'>).filter!.id as RegExp
+    expect(loadFilter.test('\0impound:proxy')).toBe(true)
+    expect(loadFilter.test('/app/assets/font.woff2')).toBe(false)
+    expect(loadFilter.test('/app/entry.js')).toBe(false)
+  })
+
+  it('should not transform binary assets in trace mode', () => {
+    const rawPlugins = ImpoundPlugin.raw({ trace: true, patterns: [['bar']] }, { framework: 'rollup', versions: {} })
+    const plugins = Array.isArray(rawPlugins) ? rawPlugins : [rawPlugins]
+    const tracePlugin = plugins.find(p => p.name === 'impound:trace')!
+
+    const excludeFilter = ((tracePlugin.transform as ObjectHook<any, 'id'>).filter!.id as { exclude: RegExp }).exclude
+    expect(excludeFilter.test('/app/assets/font.woff2')).toBe(true)
+    expect(excludeFilter.test('/app/assets/logo.png?inline')).toBe(true)
+    expect(excludeFilter.test('/app/entry.js')).toBe(false)
+  })
+
+  it('should not transform binary assets via a converted adapter', async () => {
+    const plugins = ImpoundPlugin.rollup({ trace: true, patterns: [['bar']] }) as any[]
+    const tracePlugin = plugins.find(p => p.name === 'impound:trace')!
+
+    const getCombinedSourcemap = vi.fn(() => ({ mappings: '' }))
+
+    await tracePlugin.transform.call({ getCombinedSourcemap }, 'export default 1', '/app/assets/logo.png?inline')
+    expect(getCombinedSourcemap).not.toHaveBeenCalled()
+
+    await tracePlugin.transform.call({ getCombinedSourcemap }, 'export default 1', '/app/entry.js')
+    expect(getCombinedSourcemap).toHaveBeenCalled()
+  })
+
+  it.each(['vite', 'rolldown'] as const)('should keep the binary asset filter on the %s adapter', (framework) => {
+    const plugins = ImpoundPlugin[framework]({ trace: true, patterns: [['bar']] }) as any[]
+    const tracePlugin = plugins.find(p => p.name === 'impound:trace')!
+
+    const excludeFilter = (tracePlugin.transform as ObjectHook<any, 'id'>).filter!.id as { exclude: RegExp }
+    expect(excludeFilter.exclude.test('/app/assets/font.woff2')).toBe(true)
+    expect(excludeFilter.exclude.test('/app/assets/logo.png?inline')).toBe(true)
+    expect(excludeFilter.exclude.test('/app/entry.js')).toBe(false)
+  })
+})


### PR DESCRIPTION
this adds transform/load filters to improve performance and fix some issues when using with webpack/rspack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module handling so only recognized proxy modules are processed.
  * Prevented trace-mode processing from modifying binary assets.
  * Continued supporting JavaScript transformations in trace mode.
* **Reliability**
  * Added validation to ensure filtering works correctly across supported module and asset types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->