### PR TITLE
perf: some performance improvements 🔥

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -419,57 +419,76 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
   // Violations waiting for the importer's transform to complete
   const pendingViolations = new Map<string, PendingViolation[]>()
 
-  const plugins: UnpluginOptions[] = matchers.map((options) => {
-    const filter = createFilter(options.include, options.exclude, { resolve: globalOptions.cwd })
-    const excludeFilter = options.excludeFiles?.length
-      ? createFilter(options.excludeFiles, undefined, { resolve: globalOptions.cwd })
-      : undefined
-    const warnedMessages = options.warn !== 'always' ? new Set<string>() : undefined
+  const cwd = globalOptions.cwd
 
-    return {
-      name: 'impound',
-      enforce: 'pre' as const,
-      load: {
-        filter: { id: PROXY_ID_RE },
-        handler(id: string) {
-          if (id === PROXY_ID) {
-            return PROXY_CODE
-          }
-        },
-      },
-      resolveId(this: UnpluginBuildContext & UnpluginContext, id: string, importer: string | undefined, resolveOptions?: { isEntry?: boolean }) {
+  interface MatcherState {
+    options: ImpoundMatcherOptions
+    filter: (id: string) => boolean
+    excludeFilter?: (id: string) => boolean
+    warnedMessages?: Set<string>
+  }
+
+  const matcherStates: MatcherState[] = matchers.map(options => ({
+    options,
+    filter: createFilter(options.include, options.exclude, { resolve: cwd }),
+    excludeFilter: options.excludeFiles?.length
+      ? createFilter(options.excludeFiles, undefined, { resolve: cwd })
+      : undefined,
+    warnedMessages: options.warn !== 'always' ? new Set<string>() : undefined,
+  }))
+
+  const plugins: UnpluginOptions[] = [{
+    name: 'impound',
+    enforce: 'pre' as const,
+    load: {
+      filter: { id: PROXY_ID_RE },
+      handler(id: string) {
         if (id === PROXY_ID) {
-          return id
+          return PROXY_CODE
         }
-        if (!importer) {
-          // This is an entry point resolution
-          if (traceEnabled && resolveOptions?.isEntry) {
-            entries.add(id)
-          }
-          return
+      },
+    },
+    resolveId(this: UnpluginBuildContext & UnpluginContext, id: string, importer: string | undefined, resolveOptions?: { isEntry?: boolean }) {
+      if (id === PROXY_ID) {
+        return id
+      }
+      if (!importer) {
+        // This is an entry point resolution
+        if (traceEnabled && resolveOptions?.isEntry) {
+          entries.add(id)
+        }
+        return
+      }
+
+      const rawId = id
+      // Lazily computed once per call and shared across matchers
+      let resolvedId: string | undefined
+      let relativeId: string | undefined
+      let relativeImporter: string | undefined
+      let trackedForTrace = false
+
+      for (const matcher of matcherStates) {
+        if (!matcher.filter(importer)) {
+          continue
         }
 
-        if (!filter(importer)) {
-          return
-        }
-
-        const rawId = id
-
-        if (RELATIVE_IMPORT_RE.test(id)) {
-          id = join(importer.split('?')[0]!, '..', id)
-        }
+        resolvedId ??= RELATIVE_IMPORT_RE.test(rawId)
+          ? join(importer.split('?')[0]!, '..', rawId)
+          : rawId
 
         // Skip resolved targets matching excludeFiles
-        if (excludeFilter?.(id)) {
-          return
+        if (matcher.excludeFilter?.(resolvedId)) {
+          continue
         }
 
-        if (isAbsolute(id) && globalOptions.cwd) {
-          id = relative(globalOptions.cwd, id)
-        }
+        relativeId ??= isAbsolute(resolvedId) && cwd ? relative(cwd, resolvedId) : resolvedId
+        const id = relativeId
+
+        relativeImporter ??= isAbsolute(importer) && cwd ? relative(cwd, importer) : importer
 
         // Track resolved imports for trace mode
-        if (traceEnabled) {
+        if (traceEnabled && !trackedForTrace) {
+          trackedForTrace = true
           let importerResolved = resolvedImports.get(importer)
           if (!importerResolved) {
             importerResolved = new Map()
@@ -478,9 +497,9 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
           importerResolved.set(rawId, id)
         }
 
+        const { options, warnedMessages } = matcher
         let matched = false
 
-        const relativeImporter = isAbsolute(importer) && globalOptions.cwd ? relative(globalOptions.cwd, importer) : importer
         for (const [pattern, warning, suggestions] of options.patterns) {
           const usesImport = pattern instanceof RegExp
             ? pattern.test(id)
@@ -508,7 +527,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
 
               if (moduleGraph.has(importer)) {
                 // Importer already transformed — enrich and report immediately
-                enrichAndReport(violation, moduleGraph, resolvedImports, entries, maxTraceDepth, globalOptions.cwd, warnedMessages)
+                enrichAndReport(violation, moduleGraph, resolvedImports, entries, maxTraceDepth, cwd, warnedMessages)
               }
               else {
                 // Importer not yet transformed (dev mode) — defer until after transform
@@ -538,10 +557,12 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
           }
         }
 
-        return matched ? PROXY_ID : null
-      },
-    }
-  })
+        if (matched) {
+          return PROXY_ID
+        }
+      }
+    },
+  }]
 
   if (traceEnabled) {
     // shared transform logic for module graph building and flushing pending violations.

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,6 +424,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
   interface MatcherState {
     options: ImpoundMatcherOptions
     filter: (id: string) => boolean
+    filterCache: Map<string, boolean>
     excludeFilter?: (id: string) => boolean
     warnedMessages?: Set<string>
   }
@@ -431,11 +432,14 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
   const matcherStates: MatcherState[] = matchers.map(options => ({
     options,
     filter: createFilter(options.include, options.exclude, { resolve: cwd }),
+    filterCache: new Map(),
     excludeFilter: options.excludeFiles?.length
       ? createFilter(options.excludeFiles, undefined, { resolve: cwd })
       : undefined,
     warnedMessages: options.warn !== 'always' ? new Set<string>() : undefined,
   }))
+
+  const relativeImporterCache = new Map<string, string>()
 
   const plugins: UnpluginOptions[] = [{
     name: 'impound',
@@ -468,7 +472,12 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
       let trackedForTrace = false
 
       for (const matcher of matcherStates) {
-        if (!matcher.filter(importer)) {
+        let included = matcher.filterCache.get(importer)
+        if (included === undefined) {
+          included = matcher.filter(importer)
+          matcher.filterCache.set(importer, included)
+        }
+        if (!included) {
           continue
         }
 
@@ -484,7 +493,13 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
         relativeId ??= isAbsolute(resolvedId) && cwd ? relative(cwd, resolvedId) : resolvedId
         const id = relativeId
 
-        relativeImporter ??= isAbsolute(importer) && cwd ? relative(cwd, importer) : importer
+        if (relativeImporter === undefined) {
+          relativeImporter = relativeImporterCache.get(importer)
+          if (relativeImporter === undefined) {
+            relativeImporter = isAbsolute(importer) && cwd ? relative(cwd, importer) : importer
+            relativeImporterCache.set(importer, relativeImporter)
+          }
+        }
 
         // Track resolved imports for trace mode
         if (traceEnabled && !trackedForTrace) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -514,6 +514,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
 
         const { options, warnedMessages } = matcher
         let matched = false
+        let formattedImporter: string | undefined
 
         for (const [pattern, warning, suggestions] of options.patterns) {
           const usesImport = pattern instanceof RegExp
@@ -523,7 +524,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
               : pattern(id, relativeImporter)
 
           if (usesImport) {
-            const formattedImporter = relativeImporter.split('?')[0]!
+            formattedImporter ??= relativeImporter.split('?')[0]!
             const baseMessage = `${typeof usesImport === 'string' ? usesImport : (warning || 'Invalid import')} [importing \`${id}\` from \`${formattedImporter}\`]`
 
             if (traceEnabled) {


### PR DESCRIPTION
### 📚 Description

`resolveId` runs for every import of every module, and in a Nuxt project (which passes several `matchers`) that adds up fast.

this PR aims to speed up the hot path ~5x:

| scenario (3 matchers, 4,000 resolutions) | before | after | delta |
| - | - | - | - |
| cold (first pass over module graph) | 15.80ms | 3.24ms | -79% |
| warm dev server (repeated resolutions) | 15.56ms | 2.93ms | -81% |
| memory allocated per pass (warm) | 14.8MB | 5.1MB | -66% |

<details><summary>full mitata output</summary>
<p>


```
clk: ~3.71 GHz
cpu: unknown
runtime: node 22.22.2 (arm64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• cold: fresh plugin per iteration (3 matchers, 4000 resolutions)
------------------------------------------- -------------------------------
main                          16.56 ms/iter  16.65 ms  ▃█                  
                      (15.88 ms … 19.51 ms)  18.90 ms ▃██▆ ▃               
                    (  1.28 mb …   1.53 mb)   1.29 mb ████▆█▁▁▆▄▁▁▁▆▄▁▁▁▁▁▄

merged plugin                  7.67 ms/iter   7.71 ms  █                   
                        (7.37 ms … 8.98 ms)   8.84 ms  █▂█                 
                    ( 13.24 mb …  13.24 mb)  13.24 mb ▄████▇▇▁▂▃▁▃▃▂▁▁▂▁▁▂▂

+ importer caches              3.22 ms/iter   3.26 ms   ▅█                 
                        (3.06 ms … 4.76 ms)   3.94 ms ▃▇███▆               
                    (  5.57 mb …   5.58 mb)   5.57 mb ███████▃▃▃▃▁▁▁▁▁▁▁▁▁▂

+ hoist formatting (final)     3.20 ms/iter   3.26 ms   ▄█                 
                        (3.07 ms … 3.76 ms)   3.46 ms  ▆██▆▇▅ █▄ ▆         
                    (  5.57 mb …   5.58 mb)   5.57 mb ▃███████████▇▄▁▃▁▃▄▂▃

summary
  + hoist formatting (final)
   1.01x faster than + importer caches
   2.4x faster than merged plugin
   5.17x faster than main

• warm dev-server: long-lived plugin, repeated resolutions
------------------------------------------- -------------------------------
main                          16.78 ms/iter  16.81 ms  █▅▅                 
                      (15.58 ms … 23.59 ms)  23.03 ms ▆███                 
                    (  1.27 mb …   1.27 mb)   1.27 mb ████▆▄▁▄▁▄▁▁▁▁▁▁▁▁▁▁▄

merged plugin                  7.75 ms/iter   7.82 ms   █▅                 
                       (7.21 ms … 10.66 ms)  10.07 ms  ▃███▃               
                    ( 13.23 mb …  13.23 mb)  13.23 mb ▄█████▅▄▁▄▁▁▁▁▁▁▁▁▁▁▂

+ importer caches              2.96 ms/iter   3.01 ms   ▃▂▄█               
                        (2.78 ms … 3.42 ms)   3.38 ms  █████▅▅             
                    (  5.11 mb …   5.11 mb)   5.11 mb █████████▇▇▇▅▃▆▄▂▂▁▂▂

+ hoist formatting (final)     2.98 ms/iter   3.05 ms     █ ▃▂▄█           
                        (2.79 ms … 3.30 ms)   3.24 ms   ▅▆█▃████▇▅▆▃       
                    (  5.11 mb …   5.11 mb)   5.11 mb ▂█████████████▇█▅▃▇▁▃

summary
  + importer caches
   1.01x faster than + hoist formatting (final)
   2.62x faster than merged plugin
   5.67x faster than main
```


</p>
</details> 

two changes accont for the improvement:

1. rather than having each matcher be its own plugin, we combine them into a single plugin. (this also should reduce rust -> JS crossover costs, which aren't included in above improvements)
2. we now also cache include-filter results and cwd-relative importer paths
