### PR TITLE
fix: release build state after non-watch builds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,7 @@ interface PendingViolation {
   warnedMessages: Set<string> | undefined
 }
 
+/** Detect whether the current adapter exposes Rollup-compatible watch metadata. */
 function hasWatchMode(context: UnpluginBuildContext): context is UnpluginBuildContext & { meta: { watchMode?: unknown } } {
   return 'meta' in context && typeof context.meta === 'object' && context.meta !== null && 'watchMode' in context.meta
 }
@@ -727,12 +728,13 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
     return (cachedEagerGraph ??= eagerGraph(moduleImports, resolvedImports, entries, cwd))
   }
 
-  // Trace and matcher state is build-scoped. Keep it for watch rebuilds, where the
-  // graph is needed for incremental diagnostics, but release it once a one-shot build
-  // has reported its deferred violations. In particular, source maps can retain large
-  // strings and buffers long after the transform that produced them.
-  function clearBuildState(): void {
-    if (watchMode)
+  /**
+   * Release trace and matcher state after one-shot builds and failed watch
+   * builds. Successful watch rebuilds retain the graph for incremental
+   * diagnostics; failures force cleanup because that graph is incomplete.
+   */
+  function clearBuildState(force = false): void {
+    if (watchMode && !force)
       return
 
     cachedEagerGraph = undefined
@@ -755,8 +757,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
     buildStart() {
       watchMode = hasWatchMode(this) && this.meta.watchMode === true
     },
-    // Reports deferred violations, then releases build-scoped state. The finally
-    // path also runs when reporting or the build itself fails.
+    // Reports deferred violations, then releases build-scoped state.
     buildEnd,
     load: {
       filter: { id: PROXY_ID_RE },
@@ -1056,13 +1057,16 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
     }
   }
 
+  /** Report deferred violations, then release state after one-shot builds or failures. */
   async function buildEnd(this: UnpluginBuildContext, buildError?: unknown): Promise<void> {
+    let completed = false
     try {
       if (traceEnabled)
         await reportHeldViolations.call(this, buildError)
+      completed = buildError === undefined
     }
     finally {
-      clearBuildState()
+      clearBuildState(!completed)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,10 @@ interface PendingViolation {
   warnedMessages: Set<string> | undefined
 }
 
+function hasWatchMode(context: UnpluginBuildContext): context is UnpluginBuildContext & { meta: { watchMode?: unknown } } {
+  return 'meta' in context && typeof context.meta === 'object' && context.meta !== null && 'watchMode' in context.meta
+}
+
 /** Map imports to 1-indexed lines and 0-indexed UTF-16 columns. */
 function getImportLocations(code: string, imports: readonly { n: string | undefined, s: number, ss: number, se: number }[]): Map<string, ImportLocation> {
   const locations = new Map<string, ImportLocation>()
@@ -645,6 +649,7 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
     : globalOptions.trace === true ? 'eager' : 'off'
   const traceEnabled = traceMode !== 'off'
   const maxTraceDepth = globalOptions.maxTraceDepth ?? 20
+  let watchMode = false
 
   const moduleImports = new Map<string, Map<string, ImportLocation>>()
   // Only modules a matcher includes can be the importer in a violation, so only those
@@ -722,11 +727,37 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
     return (cachedEagerGraph ??= eagerGraph(moduleImports, resolvedImports, entries, cwd))
   }
 
+  // Trace and matcher state is build-scoped. Keep it for watch rebuilds, where the
+  // graph is needed for incremental diagnostics, but release it once a one-shot build
+  // has reported its deferred violations. In particular, source maps can retain large
+  // strings and buffers long after the transform that produced them.
+  function clearBuildState(): void {
+    if (watchMode)
+      return
+
+    cachedEagerGraph = undefined
+    moduleImports.clear()
+    moduleSources.clear()
+    resolvedImports.clear()
+    entries.clear()
+    pendingViolations.clear()
+    heldMessages.clear()
+    relativeImporterCache.clear()
+    for (const matcher of matcherStates) {
+      matcher.filterCache.clear()
+      matcher.warnedMessages?.clear()
+    }
+  }
+
   const plugins: UnpluginOptions[] = [{
     name: 'impound',
     enforce: 'pre' as const,
-    // Reports any violation still held once the build's graph is complete.
-    ...(traceEnabled ? { buildEnd: reportHeldViolations } : {}),
+    buildStart() {
+      watchMode = hasWatchMode(this) && this.meta.watchMode === true
+    },
+    // Reports deferred violations, then releases build-scoped state. The finally
+    // path also runs when reporting or the build itself fails.
+    buildEnd,
     load: {
       filter: { id: PROXY_ID_RE },
       handler(id: string) {
@@ -1022,6 +1053,16 @@ export const ImpoundPlugin = createUnplugin<ImpoundOptions>((globalOptions) => {
         // esbuild exposes no module graph, so there is no chain or snippet to add.
         reportViolation(violation, [{ file: violation.relativeImporter }], undefined, cwd, errorFn, violation.warnedMessages)
       }
+    }
+  }
+
+  async function buildEnd(this: UnpluginBuildContext, buildError?: unknown): Promise<void> {
+    try {
+      if (traceEnabled)
+        await reportHeldViolations.call(this, buildError)
+    }
+    finally {
+      clearBuildState()
     }
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1791,3 +1791,73 @@ describe('hook filters', () => {
     expect(excludeFilter.exclude.test('/app/entry.js')).toBe(false)
   })
 })
+
+describe('trace state lifecycle', () => {
+  it('releases trace and warning state after a non-watch build', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const plugins = ImpoundPlugin.rollup({
+      trace: true,
+      patterns: [['secret']],
+      error: false,
+    }) as any[]
+    const impoundPlugin = plugins.find(plugin => plugin.name === 'impound')!
+    const tracePlugin = plugins.find(plugin => plugin.name === 'impound:trace')!
+    const code = 'import secret from "secret"; export default secret'
+
+    await impoundPlugin.buildStart.call({ meta: { watchMode: false } })
+    await tracePlugin.transform.call({}, code, 'entry.js')
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+
+    await impoundPlugin.buildEnd.call({})
+
+    // A second one-shot build gets a fresh warning set and can report again.
+    await tracePlugin.transform.call({}, code, 'entry.js')
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    expect(errorSpy).toHaveBeenCalledTimes(2)
+    errorSpy.mockRestore()
+  })
+
+  it('retains trace state across watch rebuilds', async () => {
+    const violations: ImpoundViolationInfo[] = []
+    const plugins = ImpoundPlugin.rollup({
+      trace: true,
+      patterns: [['secret']],
+      error: false,
+      onViolation: info => void violations.push(info),
+    }) as any[]
+    const impoundPlugin = plugins.find(plugin => plugin.name === 'impound')!
+    const tracePlugin = plugins.find(plugin => plugin.name === 'impound:trace')!
+    const code = 'import secret from "secret"; export default secret'
+
+    await impoundPlugin.buildStart.call({ meta: { watchMode: true } })
+    await tracePlugin.transform.call({}, code, 'entry.js')
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    await impoundPlugin.buildEnd.call({})
+
+    // The importer remains registered, so a watch rebuild reports immediately.
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    expect(violations).toHaveLength(2)
+  })
+
+  it('cleans state when deferred reporting receives a build error', async () => {
+    const violations: ImpoundViolationInfo[] = []
+    const plugins = ImpoundPlugin.rollup({
+      trace: true,
+      patterns: [['secret']],
+      error: false,
+      onViolation: info => void violations.push(info),
+    }) as any[]
+    const impoundPlugin = plugins.find(plugin => plugin.name === 'impound')!
+    const tracePlugin = plugins.find(plugin => plugin.name === 'impound:trace')!
+
+    await impoundPlugin.buildStart.call({ meta: { watchMode: false } })
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    await impoundPlugin.buildEnd.call({}, new Error('build failed'))
+
+    // The failed build's held violation must not leak into the next build.
+    await tracePlugin.transform.call({}, 'import secret from "secret"', 'entry.js')
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    expect(violations).toHaveLength(1)
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1840,7 +1840,7 @@ describe('trace state lifecycle', () => {
     expect(violations).toHaveLength(2)
   })
 
-  it('cleans state when deferred reporting receives a build error', async () => {
+  it('cleans trace state after a failed watch build', async () => {
     const violations: ImpoundViolationInfo[] = []
     const plugins = ImpoundPlugin.rollup({
       trace: true,
@@ -1850,14 +1850,54 @@ describe('trace state lifecycle', () => {
     }) as any[]
     const impoundPlugin = plugins.find(plugin => plugin.name === 'impound')!
     const tracePlugin = plugins.find(plugin => plugin.name === 'impound:trace')!
+    const code = 'import secret from "secret"; export default secret'
 
-    await impoundPlugin.buildStart.call({ meta: { watchMode: false } })
+    await impoundPlugin.buildStart.call({ meta: { watchMode: true } })
+    await tracePlugin.transform.call({}, code, 'entry.js')
     await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    expect(violations).toHaveLength(1)
+
     await impoundPlugin.buildEnd.call({}, new Error('build failed'))
 
-    // The failed build's held violation must not leak into the next build.
-    await tracePlugin.transform.call({}, 'import secret from "secret"', 'entry.js')
+    // A failed watch build cannot safely reuse its incomplete graph.
     await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'entry.js')
+    expect(violations).toHaveLength(1)
+
+    await tracePlugin.transform.call({}, code, 'entry.js')
+    expect(violations).toHaveLength(2)
+  })
+
+  it('cleans trace state when deferred reporting throws', async () => {
+    const violations: ImpoundViolationInfo[] = []
+    let failReporting = true
+    const plugins = ImpoundPlugin.rollup({
+      trace: true,
+      patterns: [['secret']],
+      error: false,
+      onViolation: (info) => {
+        if (failReporting) {
+          failReporting = false
+          throw new Error('report failed')
+        }
+        violations.push(info)
+        return false
+      },
+    }) as any[]
+    const impoundPlugin = plugins.find(plugin => plugin.name === 'impound')!
+    const tracePlugin = plugins.find(plugin => plugin.name === 'impound:trace')!
+    const code = 'import secret from "secret"; export default secret'
+
+    await impoundPlugin.buildStart.call({ meta: { watchMode: true } })
+    await tracePlugin.transform.call({}, code, 'registered.js')
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'pending.js')
+
+    await expect(impoundPlugin.buildEnd.call({})).rejects.toThrow('report failed')
+
+    // Reporting failed, so even watch mode must start from a fresh graph.
+    await impoundPlugin.resolveId.call({ error: () => {} }, 'secret', 'registered.js')
+    expect(violations).toHaveLength(0)
+
+    await tracePlugin.transform.call({}, code, 'registered.js')
     expect(violations).toHaveLength(1)
   })
 })


### PR DESCRIPTION
I've been benchmarking a semi-large Nuxt 4.4.8 app that has been crashing on builds, and noticed that `impound` during Nitro's build phase took a lot of time.

I looked for opportunities, and found that impound's eager tracing keeps source, sourcemaps, resolved imports, held violations and matcher caches alive after each one-shot build, and later stages keep dragging this old graph around. Now, on this 2,405-client-module / 1,220-SSR-module app build, it always consistently was enough to OOM during Nitro's build phase, upgrading to Impound 1.2.0 helped but didn't resolve the issue.

This PR aims to clears that state after `buildEnd` reports, keeps it around in watch mode, and still cleans up when a build fails.

Results:
- Before: client / SSR took 13.29s / 4.78s, then Nitro OOMed at the stock 2,240 MiB heap limit
- After: client / SSR took 13.15s / 4.51s at the same limit, builds successfully

Benchmarked with help from GPT-5.6 Sol. Not sure if this is a fluke or a niche case here, so feel free to close if it's not useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build state handling between builds.
  * Prevented trace and warning information from leaking into subsequent one-shot builds.
  * Preserved state during watch-mode rebuilds so violations continue to be reported promptly.
  * Ensured build failures do not leave deferred violations affecting later builds.

* **Tests**
  * Added coverage for trace and warning state across standard builds, watch-mode rebuilds, and failed builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->